### PR TITLE
feat: on demand export

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,16 +25,16 @@
     "bunyan": "^1.8.1",
     "common-errors": "^0.5.7",
     "dlock": "^5.0.0",
-    "ioredis": "^2.1.0",
+    "ioredis": "^2.2.0",
     "is": "^3.1.0",
     "lodash": "^4.13.1",
     "md5": "^2.1.0",
-    "ms-amqp-transport": "^2.0.0",
+    "ms-amqp-transport": "^3.0.0",
     "ms-conf": "^2.0.0",
     "ms-files-gce": "^1.0.1",
     "ms-files-providers": "^1.0.2",
     "ms-validation": "^2.0.0",
-    "mservice": "^2.3.0",
+    "mservice": "^2.4.0",
     "redis-filtered-sort": "^1.2.0"
   },
   "optionalDependencies": {
@@ -61,7 +61,8 @@
     "md5": "^2.1.0",
     "mocha": "^2.5.3",
     "request-promise": "^3.0.0",
-    "semantic-release": "^6.3.0"
+    "semantic-release": "^6.3.0",
+    "sinon": "^1.17.4"
   },
   "release": {
     "verifyConditions": []

--- a/schemas/common.json
+++ b/schemas/common.json
@@ -28,21 +28,23 @@
         },
         "meta": {
           "type": "object",
-          "^.+$": {
-            "anyOf": [{
-              "type": "string"
-            }, {
-              "type": "number"
-            }, {
-              "type": "array",
-              "items": {
-                "oneOf": [{
-                  "type": "string"
-                }, {
-                  "type": "number"
-                }]
-              }
-            }]
+          "patternProperties": {
+            "^.+$": {
+              "anyOf": [{
+                "type": "string"
+              }, {
+                "type": "number"
+              }, {
+                "type": "array",
+                "items": {
+                  "oneOf": [{
+                    "type": "string"
+                  }, {
+                    "type": "number"
+                  }]
+                }
+              }]
+            }
           }
         }
       }

--- a/schemas/common.json
+++ b/schemas/common.json
@@ -14,6 +14,39 @@
       "type": "string",
       "pattern": "^[0-9A-Fa-f]{32}\/[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-4[0-9A-Fa-f]{3}-[89ABab][0-9A-Fa-f]{3}-[0-9A-Fa-f]{12}\/[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-4[0-9A-Fa-f]{3}-[89ABab][0-9A-Fa-f]{3}-[0-9A-Fa-f]{12}"
     },
+    "export": {
+      "type": "object",
+      "required": ["format", "compression"],
+      "properties": {
+        "format": {
+          "type": "string",
+          "enum": ["stl", "obj", "wrl"]
+        },
+        "compression": {
+          "type": "string",
+          "enum": ["zip", "gz"]
+        },
+        "meta": {
+          "type": "object",
+          "^.+$": {
+            "anyOf": [{
+              "type": "string"
+            }, {
+              "type": "number"
+            }, {
+              "type": "array",
+              "items": {
+                "oneOf": [{
+                  "type": "string"
+                }, {
+                  "type": "number"
+                }]
+              }
+            }]
+          }
+        }
+      }
+    },
     "cappasity-binary": {
       "type": "object",
       "required": ["type", "contentType", "contentLength", "contentEncoding", "md5Hash", "decompressedLength", "source-sha256"],
@@ -103,6 +136,9 @@
             "type": "string",
             "pattern": "^[^,]{1,20}$"
           }
+        },
+        "export": {
+          "$ref": "common#/definitions/export"
         }
       }
     },

--- a/schemas/process.json
+++ b/schemas/process.json
@@ -5,6 +5,9 @@
   "properties": {
     "uploadId": {
       "$ref": "common#/definitions/uuid-v4"
+    },
+    "export": {
+      "$ref": "common#/definitions/export"
     }
   }
 }

--- a/schemas/process.json
+++ b/schemas/process.json
@@ -8,6 +8,9 @@
     },
     "export": {
       "$ref": "common#/definitions/export"
+    },
+    "username": {
+      "$ref": "common#/definitions/owner"
     }
   }
 }

--- a/src/actions/process.js
+++ b/src/actions/process.js
@@ -1,6 +1,6 @@
 const Promise = require('bluebird');
 const { HttpStatusError } = require('common-errors');
-const { STATUS_UPLOADED, FILES_DATA } = require('../constant.js');
+const { STATUS_UPLOADED, STATUS_PROCESSED, STATUS_FAILED, FILES_DATA } = require('../constant.js');
 const postProcess = require('../utils/process.js');
 const fetchData = require('../utils/fetchData.js');
 
@@ -11,15 +11,23 @@ const fetchData = require('../utils/fetchData.js');
  * @return {Promise}
  */
 module.exports = function postProcessFile(opts) {
-  const { uploadId } = opts;
+  const { uploadId, export: exportSettings } = opts;
   const key = `${FILES_DATA}:${uploadId}`;
 
   return Promise
     .bind(this, key)
     .then(fetchData)
     .then(data => {
-      if (data.status !== STATUS_UPLOADED) {
-        throw new HttpStatusError(412, 'file has already been processed or upload has not been finished yet');
+      if (data.status !== STATUS_UPLOADED && data.status !== STATUS_PROCESSED && data.status !== STATUS_FAILED) {
+        throw new HttpStatusError(412, 'file is being processed or upload has not been finished yet');
+      }
+
+      if (exportSettings) {
+        if (data[exportSettings.format]) {
+          throw new HttpStatusError(418, `format "${exportSettings.format}" is already present`);
+        }
+
+        data.export = exportSettings;
       }
 
       return [key, data];

--- a/src/actions/process.js
+++ b/src/actions/process.js
@@ -3,6 +3,7 @@ const { HttpStatusError } = require('common-errors');
 const { STATUS_PENDING, STATUS_PROCESSING, STATUS_UPLOADED, STATUS_FAILED, FILES_DATA } = require('../constant.js');
 const postProcess = require('../utils/process.js');
 const fetchData = require('../utils/fetchData.js');
+const hasAccess = require('../utils/hasAccess.js');
 
 /**
  * Post process file
@@ -11,12 +12,13 @@ const fetchData = require('../utils/fetchData.js');
  * @return {Promise}
  */
 module.exports = function postProcessFile(opts) {
-  const { uploadId, export: exportSettings } = opts;
+  const { uploadId, username, export: exportSettings } = opts;
   const key = `${FILES_DATA}:${uploadId}`;
 
   return Promise
     .bind(this, key)
     .then(fetchData)
+    .then(hasAccess(username))
     .then(data => {
       const status = data.status;
 

--- a/src/constant.js
+++ b/src/constant.js
@@ -2,6 +2,8 @@ module.exports = {
   STATUS_PENDING: '1',
   STATUS_UPLOADED: '2',
   STATUS_PROCESSED: '3',
+  STATUS_PROCESSING: '4',
+
   FILES_INDEX: 'files-index',
   FILES_INDEX_PUBLIC: 'files-index-pub',
   FILES_DATA: 'files-data',

--- a/src/constant.js
+++ b/src/constant.js
@@ -3,6 +3,7 @@ module.exports = {
   STATUS_UPLOADED: '2',
   STATUS_PROCESSED: '3',
   STATUS_PROCESSING: '4',
+  STATUS_FAILED: '5',
 
   FILES_INDEX: 'files-index',
   FILES_INDEX_PUBLIC: 'files-index-pub',

--- a/src/custom/cappasity-process-post.js
+++ b/src/custom/cappasity-process-post.js
@@ -1,0 +1,36 @@
+const Promise = require('bluebird');
+const ALLOWED_TYPES = ['c-bin', 'c-texture'];
+const md5 = require('md5');
+const { FILES_OWNER_FIELD } = require('../constant.js');
+
+module.exports = function finishPost(fileData, lock) {
+  const { amqp, config } = this;
+  const { processor: { route, timeout } } = config;
+  const { export: exportSettings } = fileData;
+
+  if (!exportSettings) {
+    // no need to process
+    return null;
+  }
+
+  const message = {
+    ...fileData,
+    export: {
+      namePrefix: `${md5(fileData[FILES_OWNER_FIELD])}/${fileData.uploadId}`,
+      outputFormat: exportSettings.format,
+      compression: exportSettings.compression,
+      meta: exportSettings.meta || {},
+    },
+    files: fileData.files.filter(file => ALLOWED_TYPES.indexOf(file.type) >= 0),
+  };
+
+  return Promise
+    .bind(this)
+    .then(() => lock.extend(timeout))
+    .then(() => amqp.publishAndWait(route, message, { timeout }))
+    .then(file => {
+      fileData[message.export.outputFormat] = file.fileName;
+      fileData.files.push(file);
+      return file;
+    });
+};

--- a/src/custom/cappasity-process-pre.js
+++ b/src/custom/cappasity-process-pre.js
@@ -60,6 +60,10 @@ module.exports = function finishPost(props) {
     return Promise.try(() => parseMeta(props));
   }
 
+  if (!sourceSHA) {
+    throw new HttpStatusError(412, 'source-sha256 must be provided');
+  }
+
   // write down
   const exportedAt = Date.now().toString();
   const message = {

--- a/src/custom/cappasity-upload-pre.js
+++ b/src/custom/cappasity-upload-pre.js
@@ -1,7 +1,8 @@
+const Errors = require('common-errors');
 const Promise = require('bluebird');
 const assert = require('assert');
 
-module.exports = function extractMetadata({ files, meta }) {
+module.exports = function extractMetadata({ files, meta, temp }) {
   let sourceSHA;
 
   return Promise
@@ -32,6 +33,10 @@ module.exports = function extractMetadata({ files, meta }) {
         // must always be true if it's not a simple preview upload
         assert.equal(fileTypes['c-bin'], 1, 'must contain exactly one binary upload');
         meta.sourceSHA = sourceSHA;
+      }
+
+      if (meta.export && !temp) {
+        throw new Errors.HttpStatusError(412, 'temp must be set to true');
       }
     });
 };

--- a/src/utils/process.js
+++ b/src/utils/process.js
@@ -3,10 +3,13 @@ const omit = require('lodash/omit');
 const safeParse = require('./safeParse.js');
 const {
   STATUS_PROCESSED,
+  STATUS_PROCESSING,
+  STATUS_FAILED,
   UPLOAD_DATA,
   FILES_DATA,
   FILES_PROCESS_ERROR_FIELD,
   FILES_TAGS_FIELD,
+  FILES_STATUS_FIELD,
 } = require('../constant.js');
 
 // blacklist of metadata that must be returned
@@ -41,27 +44,42 @@ module.exports = function processFile(key, data) {
           });
 
           // create new fileData
-          const fileData = {
+          const finalizedData = {
             ...data,
             ...processedData,
-            files: JSON.stringify(files),
+            files,
             [FILES_TAGS_FIELD]: JSON.stringify(parsedTags),
-            status: STATUS_PROCESSED,
           };
 
           return redis
-            .pipeline()
-            .hmset(`${FILES_DATA}:${uploadId}`, fileData)
-            .hdel(`${FILES_DATA}:${uploadId}`, FILES_PROCESS_ERROR_FIELD)
-            .del(fileKeys)
-            .exec()
-            .return({
-              ...fileData,
-              files,
-            });
+            .hset(`${FILES_DATA}:${uploadId}`, FILES_STATUS_FIELD, STATUS_PROCESSING)
+            .return({ finalizedData, parsedTags, fileKeys });
         })
         .tap(() => lock.extend())
-        .tap(finalizedData => this.hook.call(this, 'files:process:post', finalizedData, lock))
+        .tap(container => this.hook.call(this, 'files:process:post', container.finalizedData, lock))
+        .then(container => redis
+          .pipeline()
+          .hdel(`${FILES_DATA}:${uploadId}`, FILES_PROCESS_ERROR_FIELD)
+          .hmset(`${FILES_DATA}:${uploadId}`, {
+            ...container.finalizedData,
+            files: JSON.stringify(container.finalizedData.files),
+            [FILES_STATUS_FIELD]: STATUS_PROCESSED,
+          })
+          .del(container.keys)
+          .exec()
+          .return({
+            ...container.finalizedData,
+            [FILES_TAGS_FIELD]: container.parsedTags,
+            [FILES_STATUS_FIELD]: STATUS_PROCESSED,
+          })
+        )
+        .catch(err => redis
+          .hmset(`${FILES_DATA}:${uploadId}`, {
+            [FILES_STATUS_FIELD]: STATUS_FAILED,
+            [FILES_PROCESS_ERROR_FIELD]: err.message,
+          })
+          .throw(err)
+        )
         .finally(() => lock.release());
     });
 };

--- a/test/docker.sh
+++ b/test/docker.sh
@@ -22,9 +22,9 @@ if ! [ -x "$(which docker-compose)" ]; then
 fi
 
 if [[ x"$CI" == x"true" ]]; then
-  trap "$COMPOSE stop; $COMPOSE rm -f;" EXIT
+  trap "$COMPOSE stop; $COMPOSE rm -f -v;" EXIT
 else
-  trap "printf \"to remove containers use:\n\n$COMPOSE stop;\n$COMPOSE rm -f;\n\n\"" EXIT
+  trap "printf \"to remove containers use:\n\n$COMPOSE stop;\n$COMPOSE rm -f -v;\n\n\"" EXIT
 fi
 
 # bring compose up

--- a/test/helpers/config.js
+++ b/test/helpers/config.js
@@ -1,6 +1,8 @@
 // cache env ref
 const env = process.env;
 const path = require('path');
+const sinon = require('sinon');
+const Promise = require('bluebird');
 
 try {
   env.DOTENV_FILE_PATH = env.DOTENV_FILE_PATH || path.resolve(__dirname, '../.env');
@@ -56,7 +58,15 @@ module.exports = {
     'files:upload:pre': files => files,
     // process files hook -> noop
     'files:process:pre': [],
-    'files:process:post': [],
+    'files:process:post': sinon.spy(fileData => {
+      if (!fileData.export) {
+        // skip processing
+        return null;
+      }
+
+      fileData[fileData.export.format] = 1;
+      return Promise.delay(100);
+    }),
     // alias -> username
     'files:info:pre': alias => alias,
     // update pre-processor

--- a/test/helpers/utils.js
+++ b/test/helpers/utils.js
@@ -249,6 +249,11 @@ function stopService() {
     });
 }
 
+// resets sinon
+function resetSinon() {
+  config.hooks['files:process:post'].reset();
+}
+
 //
 // bind send to specific route
 //
@@ -295,4 +300,5 @@ module.exports = exports = {
   bindSend,
   initAndUpload,
   meta,
+  resetSinon,
 };


### PR DESCRIPTION
Adds ability to request on-demand processing, as well as "export" field to be passed via metadata during initial upload.
By doing so user will instruct processor to export supplied input based on metadata provided.
Includes new data statuses, which indicate about errors during processing or that processing is ongoing