### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,9 +38,9 @@
     "ms-files-providers": "^2.0.1",
     "ms-validation": "^3.0.0",
     "mservice": "^4.4.0",
-    "node-uuid": "^1.4.7",
     "redis-filtered-sort": "^1.3.1",
-    "snyk": "^1.19.1"
+    "snyk": "^1.19.1",
+    "uuid": "^3.0.0"
   },
   "devDependencies": {
     "babel-cli": "^6.18.0",

--- a/src/actions/upload.js
+++ b/src/actions/upload.js
@@ -1,5 +1,5 @@
 const Promise = require('bluebird');
-const uuid = require('node-uuid');
+const uuid = require('uuid');
 const md5 = require('md5');
 const sumBy = require('lodash/sumBy');
 const get = require('lodash/get');

--- a/test/suites/info.js
+++ b/test/suites/info.js
@@ -1,5 +1,5 @@
 const assert = require('assert');
-const uuid = require('node-uuid');
+const uuid = require('uuid');
 
 // helpers
 const {

--- a/test/suites/list.js
+++ b/test/suites/list.js
@@ -2,7 +2,7 @@ const Promise = require('bluebird');
 const assert = require('assert');
 const faker = require('faker');
 const ld = require('lodash');
-const uuid = require('node-uuid');
+const uuid = require('uuid');
 
 // helpers
 const {


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.