### PR TITLE
fix: allow empty `types` in download request schema

### DIFF
--- a/schemas/download.json
+++ b/schemas/download.json
@@ -13,7 +13,7 @@
         },
         "types": {
             "type": "array",
-            "minItems": 1,
+            "minItems": 0,
             "uniqueItems": true,
             "items": {
                 "type": "string",
@@ -21,6 +21,8 @@
                     "c-bin",
                     "c-texture",
                     "c-preview",
+                    "image",
+                    "video",
                     "obj",
                     "stl",
                     "wrl"

--- a/src/actions/download.js
+++ b/src/actions/download.js
@@ -64,7 +64,7 @@ async function getDownloadURL({ params }) {
 
   // parse file data
   const provider = this.provider('download', data);
-  const files = (types && types.length > 0)
+  const files = Array.isArray(types) && types.length > 0
     ? data.files.filter((file) => types.includes(file.type))
     : data.files;
 

--- a/src/actions/download.js
+++ b/src/actions/download.js
@@ -64,7 +64,7 @@ async function getDownloadURL({ params }) {
 
   // parse file data
   const provider = this.provider('download', data);
-  const files = types
+  const files = (types && types.length > 0)
     ? data.files.filter((file) => types.includes(file.type))
     : data.files;
 


### PR DESCRIPTION
- Allows empty `types` in download request schema. 
- Behaviour is the same as if `types` were `undefined`.