### PR TITLE
feat: Skip owner check for files.info

### DIFF
--- a/.mdeprc.js
+++ b/.mdeprc.js
@@ -2,6 +2,9 @@ module.exports = {
   "node": "12.14.1",
   "auto_compose": true,
   "with_local_compose": true,
+  "nycReport": false,
+  "arbitrary_exec": "yarn coverage:clean",
+  "post_exec": "yarn coverage:report",
   "sleep": 35,
   "services": [
     "rabbitmq",

--- a/.nycrc
+++ b/.nycrc
@@ -11,9 +11,8 @@
   "sourceMap": false,
   "instrument": false,
   "cache": true,
+  "clean": false,
   "reporter": [
-    "lcov",
-    "json",
     "text-summary"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "compile": "rimraf ./lib && babel -d ./lib --copy-files ./src",
     "pretest": "yarn compile",
-    "test": "rimraf ./coverage && yarn lint && yarn test:e2e",
-    "test:e2e": "yarn test:e2e:cluster && yarn test:e2e:sentinel",
+    "test": "yarn lint && yarn test:e2e",
+    "test:e2e": "yarn test:e2e:cluster && yarn test:e2e:sentinel --arbitrary_exec 'echo \"skip coverage clean\"'",
     "test:e2e:cluster": "mdep test run",
     "test:e2e:sentinel": "mdep test run --docker_compose ./test/docker-compose.sentinel.yml",
     "start": "mfleet",
@@ -15,7 +15,9 @@
     "prepublishOnly": "yarn compile",
     "semantic-release": "semantic-release",
     "docker-release": "mdep docker release",
-    "release": "yarn --frozen-lockfile && yarn semantic-release"
+    "release": "yarn --frozen-lockfile && yarn semantic-release",
+    "coverage:clean": "rimraf .nyc_output",
+    "coverage:report": "yarn nyc report --reporter=lcov"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org"
@@ -74,7 +76,7 @@
     "@babel/plugin-proposal-object-rest-spread": "^7.8.3",
     "@babel/plugin-transform-strict-mode": "^7.8.3",
     "@babel/register": "^7.8.3",
-    "@makeomatic/deploy": "^10.0.1",
+    "@makeomatic/deploy": "^10.1.1",
     "@semantic-release/changelog": "^3.0.6",
     "@semantic-release/exec": "^4.0.0",
     "@semantic-release/git": "^8.0.0",

--- a/schemas/info.json
+++ b/schemas/info.json
@@ -1,23 +1,35 @@
 {
-    "$id": "info",
-    "type": "object",
+  "$id": "info",
+  "type": "object",
+  "if": { "properties": { "skipOwnerCheck": { "const": true } } },
+  "then" : {
     "required": [
-        "filename",
-        "username"
-    ],
-    "properties": {
-        "filename": {
-            "anyOf": [
-                {
-                    "$ref": "common#/definitions/uploadId"
-                },
-                {
-                    "$ref": "common#/definitions/meta/properties/alias"
-                }
-            ]
+      "filename"
+    ]
+  },
+  "else": {
+    "required": [
+      "filename",
+      "username"
+    ]
+  },
+  "properties": {
+    "skipOwnerCheck": {
+      "default": false,
+      "type": "boolean"
+    },
+    "filename": {
+      "anyOf": [
+        {
+          "$ref": "common#/definitions/uploadId"
         },
-        "username": {
-            "$ref": "common#/definitions/owner"
+        {
+          "$ref": "common#/definitions/meta/properties/alias"
         }
+      ]
+    },
+    "username": {
+      "$ref": "common#/definitions/owner"
     }
+  }
 }

--- a/schemas/info.json
+++ b/schemas/info.json
@@ -1,21 +1,23 @@
 {
   "$id": "info",
   "type": "object",
-  "if": { "properties": { "skipOwnerCheck": { "const": true } } },
+  "if": { "properties": { "checkOwner": { "const": false } } },
   "then" : {
     "required": [
+      "checkOwner",
       "filename"
     ]
   },
   "else": {
     "required": [
+      "checkOwner",
       "filename",
       "username"
     ]
   },
   "properties": {
-    "skipOwnerCheck": {
-      "default": false,
+    "checkOwner": {
+      "default": true,
       "type": "boolean"
     },
     "filename": {

--- a/src/actions/info.js
+++ b/src/actions/info.js
@@ -13,7 +13,7 @@ const resolveFilename = require('../utils/resolve-filename');
  */
 async function getFileInfo({ params }) {
   const { filename: possibleFilename, username: owner } = params;
-  const shouldPerformOwnerCheck = typeof params.skipOwnerCheck === 'boolean' ? !params.skipOwnerCheck : true;
+  const shouldPerformOwnerCheck = !params.skipOwnerCheck;
 
   const [username] = await this.hook('files:info:pre', owner);
 

--- a/src/actions/info.js
+++ b/src/actions/info.js
@@ -12,19 +12,18 @@ const resolveFilename = require('../utils/resolve-filename');
  * @return {Promise}
  */
 async function getFileInfo({ params }) {
-  const { filename: possibleFilename, username: owner } = params;
-  const shouldPerformOwnerCheck = !params.skipOwnerCheck;
+  const { filename: possibleFilename, username: owner, skipOwnerCheck } = params;
 
   const [username] = await this.hook('files:info:pre', owner);
 
-  if (shouldPerformOwnerCheck) {
+  if (!skipOwnerCheck) {
     assert(username, new NotImplementedError('files:info:pre hook must be specified to use this endpoint'));
   }
 
   const filename = await resolveFilename.call(this, possibleFilename, username);
   const file = await fetchData.call(this, `${FILES_DATA}:${filename}`);
 
-  if (shouldPerformOwnerCheck) {
+  if (!skipOwnerCheck) {
     // check that owner is a match
     // even in-case with public we want the user to specify username
     if (file[FILES_OWNER_FIELD] !== username) {

--- a/src/actions/info.js
+++ b/src/actions/info.js
@@ -1,12 +1,9 @@
 const { ActionTransport } = require('@microfleet/core');
-const Promise = require('bluebird');
 const assert = require('assert');
 const { NotImplementedError, HttpStatusError } = require('common-errors');
 const { FILES_DATA, FILES_OWNER_FIELD } = require('../constant');
 const fetchData = require('../utils/fetch-data');
 const resolveFilename = require('../utils/resolve-filename');
-
-const NOT_IMPLEMENTED_ERROR = new NotImplementedError('files:info:pre hook must be specified to use this endpoint');
 
 /**
  * File information
@@ -16,33 +13,28 @@ const NOT_IMPLEMENTED_ERROR = new NotImplementedError('files:info:pre hook must 
  */
 async function getFileInfo({ params }) {
   const { filename: possibleFilename, username: owner } = params;
+  const skipOwnerCheck = typeof params.skipOwnerCheck === 'boolean' ? params.skipOwnerCheck : false;
 
-  const [username] = await Promise
-    .bind(this, ['files:info:pre', owner])
-    .spread(this.hook);
+  const [username] = await this.hook('files:info:pre', owner);
 
-  assert(username, NOT_IMPLEMENTED_ERROR);
-
-  const filename = await Promise
-    .bind(this, [possibleFilename, username])
-    .spread(resolveFilename);
-
-  const file = await Promise
-    .bind(this, `${FILES_DATA}:${filename}`)
-    .then(fetchData);
-
-  // check that owner is a match
-  // even in-case with public we want the user to specify username
-  if (file[FILES_OWNER_FIELD] !== username) {
-    throw new HttpStatusError(401, 'please sign as an owner of this model to access it');
+  if (!skipOwnerCheck) {
+    assert(username, new NotImplementedError('files:info:pre hook must be specified to use this endpoint'));
   }
 
-  // rewire owner to requested username
-  file.owner = owner;
+  const filename = await resolveFilename.call(this, possibleFilename, username);
+  const file = await fetchData.call(this, `${FILES_DATA}:${filename}`);
 
-  await Promise
-    .bind(this, ['files:info:post', file])
-    .spread(this.hook);
+  if (!skipOwnerCheck) {
+    // check that owner is a match
+    // even in-case with public we want the user to specify username
+    if (file[FILES_OWNER_FIELD] !== username) {
+      throw new HttpStatusError(401, 'please sign as an owner of this model to access it');
+    }
+    // rewire owner to requested username
+    file.owner = owner;
+  }
+
+  await this.hook('files:info:post', file);
 
   return { username, file };
 }

--- a/src/actions/info.js
+++ b/src/actions/info.js
@@ -13,18 +13,18 @@ const resolveFilename = require('../utils/resolve-filename');
  */
 async function getFileInfo({ params }) {
   const { filename: possibleFilename, username: owner } = params;
-  const skipOwnerCheck = typeof params.skipOwnerCheck === 'boolean' ? params.skipOwnerCheck : false;
+  const shouldPerformOwnerCheck = typeof params.skipOwnerCheck === 'boolean' ? !params.skipOwnerCheck : true;
 
   const [username] = await this.hook('files:info:pre', owner);
 
-  if (!skipOwnerCheck) {
+  if (shouldPerformOwnerCheck) {
     assert(username, new NotImplementedError('files:info:pre hook must be specified to use this endpoint'));
   }
 
   const filename = await resolveFilename.call(this, possibleFilename, username);
   const file = await fetchData.call(this, `${FILES_DATA}:${filename}`);
 
-  if (!skipOwnerCheck) {
+  if (shouldPerformOwnerCheck) {
     // check that owner is a match
     // even in-case with public we want the user to specify username
     if (file[FILES_OWNER_FIELD] !== username) {

--- a/src/actions/info.js
+++ b/src/actions/info.js
@@ -12,18 +12,18 @@ const resolveFilename = require('../utils/resolve-filename');
  * @return {Promise}
  */
 async function getFileInfo({ params }) {
-  const { filename: possibleFilename, username: owner, skipOwnerCheck } = params;
+  const { filename: possibleFilename, username: owner, checkOwner } = params;
 
   const [username] = await this.hook('files:info:pre', owner);
 
-  if (!skipOwnerCheck) {
+  if (checkOwner) {
     assert(username, new NotImplementedError('files:info:pre hook must be specified to use this endpoint'));
   }
 
   const filename = await resolveFilename.call(this, possibleFilename, username);
   const file = await fetchData.call(this, `${FILES_DATA}:${filename}`);
 
-  if (!skipOwnerCheck) {
+  if (checkOwner) {
     // check that owner is a match
     // even in-case with public we want the user to specify username
     if (file[FILES_OWNER_FIELD] !== username) {

--- a/test/suites/info.js
+++ b/test/suites/info.js
@@ -5,7 +5,6 @@ const uuid = require('uuid');
 const {
   startService,
   stopService,
-  inspectPromise,
   owner,
   modelData,
   bindSend,
@@ -33,156 +32,117 @@ describe('info suite', function suite() {
   // tear-down
   after('stop service', stopService);
 
-  it('404 on missing filename/upload-id', function test() {
-    return this
-      .send({ filename: uuid.v4(), username: owner })
-      .reflect()
-      .then(inspectPromise(false))
-      .then((err) => {
-        assert.equal(err.statusCode, 404);
-        return null;
-      });
+  it('404 on missing filename/upload-id', async function test() {
+    const req = this.send({ filename: uuid.v4(), username: owner });
+    await assert.rejects(req, { statusCode: 404 });
   });
 
-  it('401 on valid upload id, invalid user', function test() {
-    return this
-      .send({ filename: this.response.uploadId, username: 'martial@arts.com' })
-      .reflect()
-      .then(inspectPromise(false))
-      .then((err) => {
-        assert.equal(err.statusCode, 401);
-        return null;
-      });
+  it('401 on valid upload id, invalid user', async function test() {
+    const req = this.send({ filename: this.response.uploadId, username: 'martial@arts.com' });
+    await assert.rejects(req, { statusCode: 401 });
   });
 
-  it('STATUS_PENDING on valid upload id', function test() {
-    return this
-      .send({ filename: this.response.uploadId, username: owner })
-      .reflect()
-      .then(inspectPromise())
-      .then((rsp) => {
-        assert.equal(rsp.username, owner);
-        assert.deepEqual(rsp.file, this.response);
-        assert.equal(rsp.file.embed, undefined);
-        assert.equal(rsp.file.status, STATUS_PENDING);
-        return null;
-      });
+  it('STATUS_PENDING on valid upload id', async function test() {
+    const rsp = await this.send({ filename: this.response.uploadId, username: owner });
+    assert.equal(rsp.username, owner);
+    assert.deepEqual(rsp.file, this.response);
+    assert.equal(rsp.file.embed, undefined);
+    assert.equal(rsp.file.status, STATUS_PENDING);
   });
 
   describe('after upload', function afterUploadSuite() {
-    before('complete upload', function pretest() {
-      return finishUpload.call(this, this.response);
+    before('complete upload', async function pretest() {
+      await finishUpload.call(this, this.response);
     });
 
-    it('401 on invalid user id', function test() {
-      return this
-        .send({ filename: this.response.uploadId, username: 'martial@arts.com' })
-        .reflect()
-        .then(inspectPromise(false))
-        .then((err) => {
-          assert.equal(err.statusCode, 401);
-          return null;
-        });
+    it('401 on invalid user id', async function test() {
+      const req = this.send({ filename: this.response.uploadId, username: 'martial@arts.com' });
+      await assert.rejects(req, { statusCode: 401 });
     });
 
-    it('STATUS_UPLOADED on valid user id', function test() {
-      return this
-        .send({ filename: this.response.uploadId, username: owner })
-        .reflect()
-        .then(inspectPromise())
-        .then((rsp) => {
-          assert.equal(rsp.username, owner);
-          assert.equal(rsp.file.status, STATUS_UPLOADED);
-          return null;
-        });
+    it('400 on missing username', async function test() {
+      const req = this.send({ filename: this.response.uploadId });
+      await assert.rejects(req, { statusCode: 400 });
+    });
+
+    it('not throws 401 if noCheckOwner is set', async function testInfoInternal() {
+      const { file } = await this.send({ filename: this.response.uploadId, skipOwnerCheck: true });
+      assert.equal(file.owner, owner);
+      assert.equal(file.uploadId, this.response.uploadId);
+    });
+
+    it('STATUS_UPLOADED on valid user id', async function test() {
+      const rsp = await this.send({ filename: this.response.uploadId, username: owner });
+      assert.equal(rsp.username, owner);
+      assert.equal(rsp.file.status, STATUS_UPLOADED);
     });
 
     describe('after processed', function afterProcessedSuite() {
-      before('process file', function pretest() {
-        return processUpload.call(this, this.response);
+      before('process file', async function pretest() {
+        await processUpload.call(this, this.response);
       });
 
-      it('returns 401 on invalid user id', function test() {
-        return this
-          .send({ filename: this.response.uploadId, username: 'martial@arts.com' })
-          .reflect()
-          .then(inspectPromise(false))
-          .then((err) => {
-            assert.equal(err.statusCode, 401);
-            return null;
-          });
+      it('returns 401 on invalid user id', async function test() {
+        const req = this.send({ filename: this.response.uploadId, username: 'martial@arts.com' });
+        await assert.rejects(req, { statusCode: 401 });
       });
 
-      it('returns correct STATUS_PROCESSED', function test() {
-        return this
-          .send({ filename: this.response.uploadId, username: owner })
-          .reflect()
-          .then(inspectPromise())
-          .then((rsp) => {
-            assert.equal(rsp.username, owner);
-            assert.equal(rsp.file.status, STATUS_PROCESSED);
+      it('returns correct STATUS_PROCESSED', async function test() {
+        const rsp = await this.send({ filename: this.response.uploadId, username: owner });
+        assert.equal(rsp.username, owner);
+        assert.equal(rsp.file.status, STATUS_PROCESSED);
 
-            assert.ok(Array.isArray(rsp.file.controlsData));
-            assert.ok(Array.isArray(rsp.file.tags));
+        assert.ok(Array.isArray(rsp.file.controlsData));
+        assert.ok(Array.isArray(rsp.file.tags));
 
-            assert.equal(rsp.file.controlsData.length, 29);
-            assert.deepEqual(rsp.file.tags, ['ok', 'done']);
+        assert.equal(rsp.file.controlsData.length, 29);
+        assert.deepEqual(rsp.file.tags, ['ok', 'done']);
 
-            assert.ifError(rsp.file.public);
+        assert.ifError(rsp.file.public);
 
-            assert.ok(rsp.file.files);
-            rsp.file.files.forEach((file) => {
-              assert.ok(file.contentLength);
-              if (file.type === 'c-bin') {
-                assert.ok(file.decompressedLength);
-                assert.ok(file.decompressedLength > file.contentLength);
-              }
-            });
+        assert.ok(rsp.file.files);
+        rsp.file.files.forEach((file) => {
+          assert.ok(file.contentLength);
+          if (file.type === 'c-bin') {
+            assert.ok(file.decompressedLength);
+            assert.ok(file.decompressedLength > file.contentLength);
+          }
+        });
 
-            assert.ok(rsp.file.embed);
-            assert.ok(rsp.file.embed.code);
-            assert.equal(typeof rsp.file.embed.code, 'string');
-            assert.notEqual(rsp.file.embed.code.length, 0);
-            assert.ok(rsp.file.embed.params);
+        assert.ok(rsp.file.embed);
+        assert.ok(rsp.file.embed.code);
+        assert.equal(typeof rsp.file.embed.code, 'string');
+        assert.notEqual(rsp.file.embed.code.length, 0);
+        assert.ok(rsp.file.embed.params);
 
-            Object.keys(rsp.file.embed.params).forEach((key) => {
-              const param = rsp.file.embed.params[key];
-              assert.ok(param.type);
-              assert.notStrictEqual(param.default, undefined);
-              assert.ok(param.description);
-            });
-
-            return null;
-          });
+        Object.keys(rsp.file.embed.params).forEach((key) => {
+          const param = rsp.file.embed.params[key];
+          assert.ok(param.type);
+          assert.notStrictEqual(param.default, undefined);
+          assert.ok(param.description);
+        });
       });
 
       describe('public file', function publicSuite() {
-        before('make public', function pretest() {
-          return updateAccess.call(this, this.response.uploadId, owner, true);
+        before('make public', async function pretest() {
+          await updateAccess.call(this, this.response.uploadId, owner, true);
         });
 
-        it('returns info when file is public', function test() {
-          return this
-            .send({ filename: this.response.uploadId, username: owner })
-            .reflect()
-            .then(inspectPromise())
-            .then((rsp) => {
-              assert.equal(rsp.username, owner);
-              assert.equal(rsp.file.owner, owner);
-              assert.equal(rsp.file.public, '1');
-              assert.equal(rsp.file.status, STATUS_PROCESSED);
+        it('returns info when file is public', async function test() {
+          const rsp = await this.send({ filename: this.response.uploadId, username: owner });
+          assert.equal(rsp.username, owner);
+          assert.equal(rsp.file.owner, owner);
+          assert.equal(rsp.file.public, '1');
+          assert.equal(rsp.file.status, STATUS_PROCESSED);
 
-              assert.ok(rsp.file.files);
-              rsp.file.files.forEach((file) => {
-                assert.ok(file.contentLength);
-                if (file.type === 'c-bin') {
-                  assert.ok(file.decompressedLength);
-                  assert.ok(file.decompressedLength > file.contentLength);
-                }
-              });
-
-              return null;
-            });
+          assert.ok(rsp.file.files);
+          rsp.file.files.forEach((file) => {
+            assert.ok(file.contentLength);
+            if (file.type === 'c-bin') {
+              assert.ok(file.decompressedLength);
+              assert.ok(file.decompressedLength > file.contentLength);
+            }
+          });
         });
       });
     });

--- a/test/suites/info.js
+++ b/test/suites/info.js
@@ -32,10 +32,10 @@ describe('info suite', function suite() {
   // tear-down
   after('stop service', stopService);
 
-  it('#validation skipOwnerCheck invalid type', () => {
+  it('#validation checkOwner invalid type', () => {
     it('invalid username', async function testInfoInternal() {
-      const req = this.send({ filename: this.response.uploadId, username: owner, skipOwnerCheck: 'some' });
-      await assert.rejects(req, /skipOwnerCheck/);
+      const req = this.send({ filename: this.response.uploadId, username: owner, checkOwner: 'some' });
+      await assert.rejects(req, /checkOwner/);
     });
   });
 
@@ -53,30 +53,30 @@ describe('info suite', function suite() {
 
   describe('#validation owner check disabled', () => {
     it('returns information without username', async function testInfoInternal() {
-      const { file } = await this.send({ filename: this.response.uploadId, skipOwnerCheck: true });
+      const { file } = await this.send({ filename: this.response.uploadId, checkOwner: false });
       assert.equal(file.owner, owner);
       assert.equal(file.uploadId, this.response.uploadId);
     });
 
     it('returns information with username', async function testInfoInternal() {
-      const { file, username } = await this.send({ filename: this.response.uploadId, skipOwnerCheck: true, username: 'some' });
+      const { file, username } = await this.send({ filename: this.response.uploadId, checkOwner: false, username: 'some' });
       assert.equal(file.owner, owner);
       assert.equal(username, 'some');
       assert.equal(file.uploadId, this.response.uploadId);
     });
 
     it('invalid username', async function testInfoInternal() {
-      const req = this.send({ filename: this.response.uploadId, username: 123, skipOwnerCheck: true });
+      const req = this.send({ filename: this.response.uploadId, username: 123, checkOwner: false });
       await assert.rejects(req, /username/);
     });
 
     it('filename missing', async function testInfoInternal() {
-      const req = this.send({ skipOwnerCheck: true });
+      const req = this.send({ checkOwner: false });
       await assert.rejects(req, /filename/);
     });
 
     it('filename numeric', async function testInfoInternal() {
-      const req = this.send({ filename: 123, skipOwnerCheck: true });
+      const req = this.send({ filename: 123, checkOwner: false });
       await assert.rejects(req, /filename/);
     });
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -787,10 +787,10 @@
     alce "1.x.x"
     yargs "15.1.0"
 
-"@makeomatic/deploy@^10.0.1":
-  version "10.0.1"
-  resolved "https://registry.yarnpkg.com/@makeomatic/deploy/-/deploy-10.0.1.tgz#69ff565d26f5c9a55b5015f9cdd1f303cee69b45"
-  integrity sha512-s4h1SJXiIjM2UkTM4QqS818hQKLDI3TGgEJcyVATvCH/7REJRnFFAwxgzzPuGipaXqsck4QjEUeRLAdPWobPWw==
+"@makeomatic/deploy@^10.1.1":
+  version "10.1.1"
+  resolved "https://registry.yarnpkg.com/@makeomatic/deploy/-/deploy-10.1.1.tgz#2cb96a1d6d3203f5d09bb203456f7c74c332832c"
+  integrity sha512-qfZIh8ZlWPF9MjYTmlXgQzjiGX+vAa3lNZcMEhxN52oVbWFiHskpjIcuNbB5dUr+HNhYFMhdourrQdVdVSCfZQ==
   dependencies:
     "@commitlint/cli" "^8.3.5"
     bluebird "^3.7.2"
@@ -799,7 +799,7 @@
     death "^1.1.0"
     find-up "^4.1.0"
     glob "^7.1.6"
-    husky "^4.0.10"
+    husky "^4.2.1"
     hyperid "^2.0.3"
     is "^3.2.1"
     js-yaml "^3.13.1"
@@ -811,7 +811,7 @@
     pino "^5.16.0"
     read-pkg "^5.2.0"
     rimraf "^3.0.0"
-    semantic-release "16.0.2"
+    semantic-release "16.0.3"
     shelljs "^0.8.3"
     strip-final-newline "^2.0.0"
     yargs "^15.1.0"
@@ -4359,10 +4359,10 @@ humanize-ms@^1.2.1:
   dependencies:
     ms "^2.0.0"
 
-husky@^4.0.10:
-  version "4.2.1"
-  resolved "https://registry.yarnpkg.com/husky/-/husky-4.2.1.tgz#b09f1bd9129e6c323cc515dc17081d0615e2d7c1"
-  integrity sha512-Qa0lRreeIf4Tl92sSs42ER6qc3hzoyQPPorzOrFWfPEVbdi6LuvJEqWKPk905fOWIR76iBpp7ECZNIwk+a8xuQ==
+husky@^4.2.1:
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/husky/-/husky-4.2.3.tgz#3b18d2ee5febe99e27f2983500202daffbc3151e"
+  integrity sha512-VxTsSTRwYveKXN4SaH1/FefRJYCtx+wx04sSVcOpD7N2zjoHxa+cEJ07Qg5NmV3HAK+IRKOyNVpi2YBIVccIfQ==
   dependencies:
     chalk "^3.0.0"
     ci-info "^2.0.0"
@@ -7862,10 +7862,10 @@ secure-keys@^1.0.0:
   resolved "https://registry.yarnpkg.com/secure-keys/-/secure-keys-1.0.0.tgz#f0c82d98a3b139a8776a8808050b824431087fca"
   integrity sha1-8MgtmKOxOah3aogIBQuCRDEIf8o=
 
-semantic-release@16.0.2:
-  version "16.0.2"
-  resolved "https://registry.yarnpkg.com/semantic-release/-/semantic-release-16.0.2.tgz#4570b84324cbc2a82e71dbb75208b9f6c6c81570"
-  integrity sha512-KQmPGJvhB3qn49pFGnAuSm8txOV6nLWrUg/jQG+1CYfg7rrroVKqpZ9mmA6+PjfoFCroQ0Na7Ee5DuzHiR6e/A==
+semantic-release@16.0.3:
+  version "16.0.3"
+  resolved "https://registry.yarnpkg.com/semantic-release/-/semantic-release-16.0.3.tgz#af152cbbc7e8d9b694ecb345f539219a2d10749f"
+  integrity sha512-k9AFk0v1AM241R2+d16Z0W6q7qjkd8bmKcpLfpE+8tttynwjOfJVrrqyAAzTscS+V/lTKqvJNZJVRjlyIkAYUg==
   dependencies:
     "@semantic-release/commit-analyzer" "^7.0.0"
     "@semantic-release/error" "^2.2.0"


### PR DESCRIPTION
Allow `files.info` method to get information about file without username and owner check using special parameter.
Fix Coverage for tests: Now cluster and sentinel tests generate merged report.